### PR TITLE
expose insertPointCloud discretize= flag and add batch node updates

### DIFF
--- a/octomap/octomap_defs.pxd
+++ b/octomap/octomap_defs.pxd
@@ -130,7 +130,7 @@ cdef extern from "include_and_setting.h" namespace "octomap":
         bool isNodeOccupied(OcTreeNode& occupancyNode)
         bool isNodeAtThreshold(OcTreeNode& occupancyNode)
         void insertPointCloud(Pointcloud& scan, point3d& sensor_origin,
-                              double maxrange, bool lazy_eval)
+                              double maxrange, bool lazy_eval, bool discretize)
         OccupancyOcTreeBase[OcTreeNode].tree_iterator begin_tree(unsigned char maxDepth) except +
         OccupancyOcTreeBase[OcTreeNode].tree_iterator end_tree() except +
         OccupancyOcTreeBase[OcTreeNode].leaf_iterator begin_leafs(unsigned char maxDepth) except +

--- a/test/octomap_test.py
+++ b/test/octomap_test.py
@@ -123,6 +123,48 @@ class OctreeTestCase(unittest.TestCase):
         self.assertTrue(hit)
         self.assertTrue(np.allclose(end, [1.05, 0.05, 0.05]))
 
+    def test_updateNodes(self):
+        # test points
+        test_point1 = np.array([1.0, 2.0, 3.0])
+        test_point2 = np.array([0.0, 0.0, 0.0])
+        test_point3 = np.array([5.0, 5.0, 5.0])
+
+        # *not* present
+        node1 = self.tree.search(test_point1)
+        node2 = self.tree.search(test_point2)
+        node3 = self.tree.search(test_point3)
+        self.assertRaises(octomap.NullPointerException, lambda : self.tree.isNodeOccupied(node1))
+        self.assertRaises(octomap.NullPointerException, lambda : self.tree.isNodeOccupied(node2))
+        self.assertRaises(octomap.NullPointerException, lambda : self.tree.isNodeOccupied(node3))
+
+        # batch update w/ test points
+        self.tree.updateNodes([test_point1, test_point2, test_point3], True)
+
+        # occupied
+        node1 = self.tree.search(test_point1)
+        node2 = self.tree.search(test_point2)
+        node3 = self.tree.search(test_point3)
+        self.assertTrue(self.tree.isNodeOccupied(node1))
+        self.assertTrue(self.tree.isNodeOccupied(node2))
+        self.assertTrue(self.tree.isNodeOccupied(node3))
+
+    def test_insertDiscretizedPointCloud(self):
+        test_point1 = np.array([1.0, 2.0, 3.0])
+        test_point2 = np.array([0.0, 0.0, 0.0])
+        test_point3 = np.array([5.0, 5.0, 5.0])
+
+        self.tree.insertPointCloud(np.array([test_point1]),
+                                   np.array([0.0, 0.0, 0.0]),
+                                   discretize=True)
+
+        node1 = self.tree.search(test_point1)
+        node2 = self.tree.search(test_point2)
+        node3 = self.tree.search(test_point3)
+
+        self.assertTrue(self.tree.isNodeOccupied(node1))
+        self.assertFalse(self.tree.isNodeOccupied(node2))
+        self.assertRaises(octomap.NullPointerException, lambda : self.tree.isNodeOccupied(node3))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
gave some quick performance boosts when building/cleaning maps. `discretize=` defaults to `False` as before.